### PR TITLE
Added tflite test util and example

### DIFF
--- a/pre-release/python/iree/samples/tflite2iree/posenet_test.py
+++ b/pre-release/python/iree/samples/tflite2iree/posenet_test.py
@@ -1,0 +1,16 @@
+
+import absl.testing
+import test_util
+
+model_path = "https://storage.googleapis.com/download.tensorflow.org/models/tflite/gpu/multi_person_mobilenet_v1_075_float.tflite"
+
+class PoseTest(test_util.TFLiteModelTest):
+  def __init__(self, *args, **kwargs):
+    super(PoseTest, self).__init__(model_path, *args, **kwargs)
+
+  def test_compile_tflite(self):
+    self.compile_and_execute() 
+
+if __name__ == '__main__':
+  absl.testing.absltest.main()
+


### PR DESCRIPTION
Example is a test that download the posenet model, compiles with the TFLite
frontend, executes via IREE, and compares with the tflite interpreter.
Result differences are printed.

Future versions should find real input data to validate the results instead
of using all zeros.