### PR TITLE
Use python from venv to install requirements.

### DIFF
--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -21,9 +21,10 @@ function die() {
 $PYTHON -m venv "$VENV_DIR" || die "Could not create venv."
 source "$VENV_DIR/bin/activate" || die "Could not activate venv"
 
-# Upgrade pip.
-$PYTHON -m pip install --upgrade pip || die "Could not upgrade pip"
-$PYTHON -m pip install --upgrade -r "$TD/requirements.txt"
+# Upgrade pip and install requirements. 'python' is used here in order to
+# reference to the python executable from the venv.
+python -m pip install --upgrade pip || die "Could not upgrade pip"
+python -m pip install --upgrade -r "$TD/requirements.txt"
 
 echo "Activate venv with:"
 echo "  source $VENV_DIR/bin/activate"


### PR DESCRIPTION
Use the python from venv instead of the system python to install required packages; otherwise the packages will be installed to the system.

According to the [venv doc](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#activating-a-virtual-environment), `python` in venv will point to the right python executable.