### PR TITLE
Mark failing regressions tests as expected failures

### DIFF
--- a/tflitehub/bird_classifier_test.py
+++ b/tflitehub/bird_classifier_test.py
@@ -1,4 +1,5 @@
 # RUN: %PYTHON %s
+# XFAIL: *
 
 import absl.testing
 import numpy

--- a/tflitehub/mobilenet_ssd_quant_test.py
+++ b/tflitehub/mobilenet_ssd_quant_test.py
@@ -1,4 +1,5 @@
 # RUN: %PYTHON %s
+# XFAIL: *
 
 import absl.testing
 import numpy


### PR DESCRIPTION
bird_classifier_test.py and mobilenet_ssd_quant_test.py are failing in nightly regression tests, so they are marked as expected failures for now.  Tracking in #45 and #46