### PR TITLE
Relax test requirements to re-enable failing tests

### DIFF
--- a/tflitehub/bird_classifier_test.py
+++ b/tflitehub/bird_classifier_test.py
@@ -1,5 +1,4 @@
 # RUN: %PYTHON %s
-# XFAIL: *
 
 import absl.testing
 import numpy
@@ -16,7 +15,7 @@ class BirdClassifierTest(test_util.TFLiteModelTest):
 
   def compare_results(self, iree_results, tflite_results, details):
     super(BirdClassifierTest, self).compare_results(iree_results, tflite_results, details)
-    self.assertTrue(numpy.isclose(iree_results[0], tflite_results[0], atol=1e-3).all())
+    self.assertTrue(numpy.isclose(iree_results[0], tflite_results[0], atol=4.0).all())
 
   def generate_inputs(self, input_details):
     img_path = "https://github.com/google-coral/test_data/raw/master/bird.bmp"

--- a/tflitehub/mobilenet_ssd_quant_test.py
+++ b/tflitehub/mobilenet_ssd_quant_test.py
@@ -1,5 +1,4 @@
 # RUN: %PYTHON %s
-# XFAIL: *
 
 import absl.testing
 import numpy
@@ -19,7 +18,7 @@ class MobilenetSsdQuantTest(test_util.TFLiteModelTest):
 
   def compare_results(self, iree_results, tflite_results, details):
     super(MobilenetSsdQuantTest, self).compare_results(iree_results, tflite_results, details)
-    self.assertTrue(numpy.isclose(iree_results[0], tflite_results[0], atol=1.0).all())
+    self.assertTrue(numpy.isclose(iree_results[0], tflite_results[0], atol=2.0).all())
 
   def generate_inputs(self, input_details):
     img_path = "https://github.com/google-coral/test_data/raw/master/grace_hopper.bmp"


### PR DESCRIPTION
The TF version bump from 2.8 to 2.9 caused [bird_classifier_test.py](https://github.com/google/iree-samples/compare/main...not-jenni:failing-tests?expand=1#diff-d036c5833cb5f70fff6cc9b4d7636516330f5a924108b3e255662ad1b19b5064) and [mobilenet_ssd_quant_test.py](https://github.com/google/iree-samples/compare/main...not-jenni:failing-tests?expand=1#diff-27dbe8e7e9225dd6737f9d1c187cee4c8ebafc79d89fa487d2773e6e72999b53) to start failing, as it switched CPU kernels which slightly changed the output for quantized results.  These tests compare IREE's and TFLite's results, so the solution for now is to relax the test requirements since the output activations are still in good agreement.

Closes #45 and #46