### PR TITLE
Relax test requirements to re-enable failing test

### DIFF
--- a/tflitehub/mobilebert_tf2_quant_test.py
+++ b/tflitehub/mobilebert_tf2_quant_test.py
@@ -1,5 +1,4 @@
 # RUN: %PYTHON %s
-# XFAIL: *
 
 import absl.testing
 import numpy as np
@@ -29,8 +28,8 @@ class MobileBertTest(test_util.TFLiteModelTest):
   def compare_results(self, iree_results, tflite_results, details):
     super(MobileBertTest, self).compare_results(iree_results, tflite_results, details)
     # We have confirmed in large scale accuracy tests that differences this large is acceptable.
-    self.assertTrue(np.isclose(iree_results[0], tflite_results[0], atol=5.0).all())
-    self.assertTrue(np.isclose(iree_results[1], tflite_results[1], atol=5.0).all())
+    self.assertTrue(np.isclose(iree_results[0], tflite_results[0], atol=7.0).all())
+    self.assertTrue(np.isclose(iree_results[1], tflite_results[1], atol=7.0).all())
 
   def test_compile_tflite(self):
     self.compile_and_execute()


### PR DESCRIPTION
This test started failing after https://github.com/google/iree/pull/9337, which was known to slightly decrease the numerical accuracy when quantized softmax was de-quantized.  This updates the accuracy requirement to match the test on the main iree repo.

Closes #49